### PR TITLE
feat: add github action to publish alpha pkg

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,0 +1,39 @@
+name: Publish alpha package
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout project repository
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - uses: actions/cache@v2.1.4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      # Setup Node.js environment
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          registry-url: https://registry.npmjs.org/
+          node-version: '14.x'
+
+      - run: yarn --frozen-lockfile
+        env:
+          CI: true
+
+      # Update package version to a alpha release, including the git commit sha
+      - name: Bump package.json
+        run: |
+          npm --no-git-tag-version version $(npm show . version)-alpha.dangerous.$(git rev-parse --short HEAD)
+
+      # Publish version to npm
+      - name: Publish alpha package
+        run: npm publish --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR adds github action to release alpha version on each PR to master. so each PR can be tested easily without merging to master.

![Screenshot 2022-10-13 at 7 18 06 PM](https://user-images.githubusercontent.com/6604146/195615043-24f987d2-6d99-494b-887d-7f500394606c.png)
