### PR TITLE
fix: outputamount causing negative crash on currencyamount

### DIFF
--- a/src/elixir/entities/elixirTrade.ts
+++ b/src/elixir/entities/elixirTrade.ts
@@ -178,6 +178,11 @@ export class ElixirTrade {
       spotOutputAmount = spotOutputAmount.add(midPrice.quote(inputAmount, this.chainId))
     }
 
+    if(this.outputAmount.greaterThan(spotOutputAmount)){
+      this._priceImpact = new Percent(100, 1);
+      return this._priceImpact;
+    }
+
     const priceImpact = spotOutputAmount.subtract(this.outputAmount).divide(spotOutputAmount)
     this._priceImpact = new Percent(priceImpact.numerator, priceImpact.denominator)
 

--- a/src/elixir/entities/elixirTrade.ts
+++ b/src/elixir/entities/elixirTrade.ts
@@ -178,9 +178,9 @@ export class ElixirTrade {
       spotOutputAmount = spotOutputAmount.add(midPrice.quote(inputAmount, this.chainId))
     }
 
-    if(this.outputAmount.greaterThan(spotOutputAmount)){
-      this._priceImpact = new Percent(100, 1);
-      return this._priceImpact;
+    if (this.outputAmount.greaterThan(spotOutputAmount)) {
+      this._priceImpact = new Percent(100, 1)
+      return this._priceImpact
     }
 
     const priceImpact = spotOutputAmount.subtract(this.outputAmount).divide(spotOutputAmount)


### PR DESCRIPTION
## Summary

- Fixed outputAmount causing negative crash on Currencyamount, for some reason the outputAmount is greather than spotOutputAmount and crash fail in `new CurrencyAmount()`

## Tasks

https://app.clickup.com/t/866ag5am9